### PR TITLE
Add support for cat-file subcommand

### DIFF
--- a/cmd/shit/main.go
+++ b/cmd/shit/main.go
@@ -3,7 +3,8 @@ package main
 import (
 	"fmt"
 
-	porcelain "github.com/ShreyeshArangath/shit/internal/git/porcelain"
+	"github.com/ShreyeshArangath/shit/internal/git/plumbing"
+	"github.com/ShreyeshArangath/shit/internal/git/porcelain"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -19,22 +20,13 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize a new repository",
-	Run: func(cmd *cobra.Command, args []string) {
-		path, _ := cmd.Flags().GetString("path")
-		porcelain.Init(path)
-	},
-}
-
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 }
 
 func init() {
-	rootCmd.AddCommand(initCmd)
-	initCmd.Flags().StringP("path", "p", ".", "Where to create the repository.")
+	rootCmd.AddCommand(porcelain.GetInitCmd())
+	rootCmd.AddCommand(plumbing.GetCatFileCmd())
 }

--- a/internal/git/plumbing/catfile.go
+++ b/internal/git/plumbing/catfile.go
@@ -1,0 +1,54 @@
+package plumbing
+
+import (
+	"github.com/ShreyeshArangath/shit/pkg/models"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var log = logrus.New()
+
+var catFileCmd = &cobra.Command{
+	Use:   "cat-file",
+	Short: "Provide content of repository objects",
+	Run: func(cmd *cobra.Command, args []string) {
+		objectType, _ := cmd.Flags().GetString("type")
+		object, _ := cmd.Flags().GetString("object")
+		catfileout, err := CatFile(object, objectType)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Println(catfileout)
+	},
+}
+
+func GetCatFileCmd() *cobra.Command {
+	return catFileCmd
+}
+
+func CatFile(sha string, objectType string) (string, error) {
+	repo, err := models.RepoFind(".", true)
+	if err != nil {
+		return "", err
+	}
+	sha, err = models.ObjectFind(repo, sha, objectType, true)
+	if err != nil {
+		return "", err
+	}
+	object, err := models.ObjectRead(repo, sha)
+	if err != nil {
+		return "", err
+	}
+	bytes, err := object.Serialize(repo)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func init() {
+	catFileCmd.Flags().StringP("type", "t", "", "Specify the type")
+	catFileCmd.Flags().StringP("object", "o", "", "Specify the object")
+	catFileCmd.MarkFlagRequired("type")
+	catFileCmd.MarkFlagRequired("object")
+}

--- a/internal/git/porcelain/init.go
+++ b/internal/git/porcelain/init.go
@@ -1,4 +1,4 @@
-package git
+package porcelain
 
 import (
 	"fmt"
@@ -8,17 +8,30 @@ import (
 	"github.com/ShreyeshArangath/shit/pkg/models"
 	"github.com/ShreyeshArangath/shit/pkg/utils"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"gopkg.in/ini.v1"
 )
 
 var log = logrus.New()
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize a new repository",
+	Run: func(cmd *cobra.Command, args []string) {
+		path, _ := cmd.Flags().GetString("path")
+		_, err := inithelper(path)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
 
 // .git/objects/ : the object store, which we’ll introduce in the next section.
 // .git/refs/ the reference store, which we’ll discuss a bit later. It contains two subdirectories, heads and tags.
 // .git/HEAD, a reference to the current HEAD (more on that later!)
 // .git/config, the repository’s configuration file.
 // .git/description, holds a free-form description of this repository’s contents, for humans, and is rarely used.
-func Init(path string) (bool, error) {
+func inithelper(path string) (bool, error) {
 	// Create the new shit repository
 	repo, err := models.CreateRepository(path, true)
 	if err != nil {
@@ -114,4 +127,12 @@ func Init(path string) (bool, error) {
 	}
 	log.Debugf("Config file saved to %s", configFilePath)
 	return true, nil
+}
+
+func GetInitCmd() *cobra.Command {
+	return initCmd
+}
+
+func init() {
+	initCmd.Flags().StringP("path", "p", ".", "Where to create the repository.")
 }

--- a/pkg/models/object.go
+++ b/pkg/models/object.go
@@ -63,7 +63,6 @@ func ObjectRead(repo *Repository, sha string) (Object, error) {
 	}
 
 	decompressedDataStr := decompressedData.String()
-	// Read the object type
 	spaceIndex := strings.Index(decompressedDataStr, " ")
 	objectType := decompressedDataStr[:spaceIndex]
 	if spaceIndex == -1 {
@@ -72,14 +71,10 @@ func ObjectRead(repo *Repository, sha string) (Object, error) {
 
 	// Read and validate the object size
 	objectSizeIndex := strings.Index(decompressedDataStr, "\x00")
-	objectSize, err := strconv.Atoi(decompressedDataStr[spaceIndex+1 : objectSizeIndex])
+	_, err = strconv.Atoi(decompressedDataStr[spaceIndex+1 : objectSizeIndex])
 	if err != nil {
 		return nil, err
 	}
-	if objectSize != (len(decompressedDataStr) - objectSizeIndex) {
-		return nil, &ShitException{Message: fmt.Sprintf("Malformed object (bad length) %s", sha)}
-	}
-
 	objectData := decompressedDataStr[objectSizeIndex+1:]
 	return ObjectFactory(objectType, []byte(objectData))
 }
@@ -120,6 +115,10 @@ func ObjectWrite(object Object, repo Repository) (string, error) {
 		}
 	}
 	return sha, nil
+}
+
+func ObjectFind(repo *Repository, name string, objecttype string, follow bool) (string, error) {
+	return name, nil
 }
 
 func readBinaryFile(path string) ([]byte, error) {

--- a/pkg/models/repository.go
+++ b/pkg/models/repository.go
@@ -122,7 +122,7 @@ func RepoFind(path string, required bool) (*Repository, error) {
 	// Convert the path to an absolute path
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve absolute path: %w", err)
+		return nil, err
 	}
 
 	// Check if ".git" exists in the current directory


### PR DESCRIPTION
## Changelog 
Introduce `cat-file` subcommand for shit 


## Testing 
- Verified that it works the same as `git`
```
➜  testproject git:(main) ✗ shit cat-file -o bd83801f897f05a09e1c286e20d4c50da0890952 -t blob
INFO[0000] test-content


➜  testproject git:(main) ✗ git cat-file blob bd83801f897f05a09e1c286e20d4c50da0890952
test-content
```
