### PR TITLE
Support tag objects  

### DIFF
--- a/pkg/models/refs.go
+++ b/pkg/models/refs.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -113,4 +114,30 @@ func ListRef(repo *Repository, path string) (RefMap, error) {
 	}
 
 	return ret, nil
+}
+
+// CreateRef creates a new reference in the given repository.
+// It takes a repository pointer, a reference name, and a SHA string as inputs.
+// The function constructs the reference path, writes the SHA to the reference file,
+// and returns an error if any operation fails.
+//
+// Parameters:
+//   - repo: A pointer to the Repository where the reference will be created.
+//   - ref: The name of the reference to be created.
+//   - sha: The SHA string to be written to the reference file.
+//
+// Returns:
+//   - error: An error if any operation fails, otherwise nil.
+func CreateRef(repo *Repository, ref string, sha string) error {
+	refName := filepath.Join("refs/", ref)
+	refPath, err := repo.RepoFile(true, refName)
+	if err != nil {
+		return err
+	}
+	data := fmt.Sprintf("%s\n", sha)
+	err = os.WriteFile(refPath, []byte(data), 0644)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/models/tagmetadata.go
+++ b/pkg/models/tagmetadata.go
@@ -1,0 +1,12 @@
+package models
+
+type ShitTagMetadata struct {
+}
+
+func (s *ShitTagMetadata) Serialize() (string, error) {
+	panic("unimplemented")
+}
+
+func CreateShitTagMetadata(data string) (*ShitTagMetadata, error) {
+	panic("unimplemented")
+}

--- a/pkg/models/tagmetadata.go
+++ b/pkg/models/tagmetadata.go
@@ -1,12 +1,59 @@
 package models
 
+import (
+	"fmt"
+	"strings"
+)
+
 type ShitTagMetadata struct {
+	object     string
+	objecttype string
+	tag        string
+	tagger     string
+	message    string
 }
 
 func (s *ShitTagMetadata) Serialize() (string, error) {
-	panic("unimplemented")
+	var serialized strings.Builder
+	serialized.WriteString(fmt.Sprintf("object %s\n", s.object))
+	serialized.WriteString(fmt.Sprintf("type %s\n", s.objecttype))
+	serialized.WriteString(fmt.Sprintf("tag %s\n", s.tag))
+	serialized.WriteString(fmt.Sprintf("tagger %s\n", s.tagger))
+	serialized.WriteString("\n")
+	serialized.WriteString(s.message)
+	return serialized.String(), nil
 }
 
 func CreateShitTagMetadata(data string) (*ShitTagMetadata, error) {
-	panic("unimplemented")
+	m := &ShitTagMetadata{}
+	var ismessage bool
+	var msgbuf strings.Builder
+	for _, line := range strings.Split(data, "\n") {
+		if !ismessage {
+			line = strings.TrimSpace(line)
+			if len(line) == 0 {
+				ismessage = true
+				continue
+			}
+			split := strings.SplitN(line, " ", 2)
+			var data string
+			if len(split) == 2 {
+				data = split[1]
+			}
+			switch split[0] {
+			case "object":
+				m.object = string(data)
+			case "type":
+				m.objecttype = string(data)
+			case "tag":
+				m.tag = string(data)
+			case "tagger":
+				m.tagger = string(data)
+			}
+		} else {
+			msgbuf.WriteString(line)
+		}
+	}
+	m.message = msgbuf.String()
+	return m, nil
 }

--- a/pkg/models/tagmetadata_test.go
+++ b/pkg/models/tagmetadata_test.go
@@ -18,3 +18,13 @@ func TestShitMetadataCreate(t *testing.T) {
 	assert.Equal(t, "Shreyesh Arangath <sarangath@google.com> 1735610175 +0300", metadata.tagger)
 	assert.Equal(t, "test", metadata.message)
 }
+
+func TestShitMetadataSerialize(t *testing.T) {
+	data, err := os.ReadFile("testdata/tag")
+	assert.NoError(t, err)
+	metadata, err := CreateShitTagMetadata(string(data))
+	assert.NoError(t, err)
+	serialized, err := metadata.Serialize()
+	assert.NoError(t, err)
+	assert.Equal(t, string(data), serialized)
+}

--- a/pkg/models/tagmetadata_test.go
+++ b/pkg/models/tagmetadata_test.go
@@ -1,0 +1,20 @@
+package models
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShitMetadataCreate(t *testing.T) {
+	data, err := os.ReadFile("testdata/tag")
+	assert.NoError(t, err)
+	metadata, err := CreateShitTagMetadata(string(data))
+	assert.NoError(t, err)
+	assert.Equal(t, "1519c056ada87c66a34004a868c4f1cb188fade6", metadata.object)
+	assert.Equal(t, "commit", metadata.objecttype)
+	assert.Equal(t, "v1.0", metadata.tag)
+	assert.Equal(t, "Shreyesh Arangath <sarangath@google.com> 1735610175 +0300", metadata.tagger)
+	assert.Equal(t, "test", metadata.message)
+}

--- a/pkg/models/tagobject.go
+++ b/pkg/models/tagobject.go
@@ -1,0 +1,46 @@
+package models
+
+import "fmt"
+
+type ShitTag struct {
+	Data        []byte
+	TagMetadata *ShitTagMetadata
+}
+
+func (b *ShitTag) GetType() string {
+	return "tag"
+}
+
+func (b *ShitTag) Initialize() error {
+	return nil
+}
+
+func (b *ShitTag) Serialize(repo *Repository) ([]byte, error) {
+	serialized, err := b.TagMetadata.Serialize()
+	if err != nil {
+		return nil, &ShitException{Message: fmt.Sprintf("Failed to serialize tag object: %v", err)}
+	}
+	return []byte(serialized), nil
+}
+
+func (b *ShitTag) Deserialize(data []byte) error {
+	metadata, err := CreateShitTagMetadata(string(data))
+	b.TagMetadata = metadata
+	if err != nil {
+		return &ShitException{Message: fmt.Sprintf("Failed to deserialize tag object: %v", err)}
+	}
+	return nil
+}
+
+func NewShitTag(data []byte) (*ShitTag, error) {
+	tagObject := &ShitTag{
+		Data: data,
+	}
+	var err error
+	if len(data) == 0 {
+		err = tagObject.Initialize()
+	} else {
+		err = tagObject.Deserialize(data)
+	}
+	return tagObject, err
+}

--- a/pkg/models/testdata/tag
+++ b/pkg/models/testdata/tag
@@ -1,0 +1,6 @@
+object 1519c056ada87c66a34004a868c4f1cb188fade6
+type commit
+tag v1.0
+tagger Shreyesh Arangath <sarangath@google.com> 1735610175 +0300
+
+test


### PR DESCRIPTION
## Changelog 
Add support for tag objects for shit. Tags are essentially refs so most of the code here is reused. 

## Testing 
- Unit tests 
- Tested locally 