### PR TITLE
Add support for tag cmd

### DIFF
--- a/cmd/shit/main.go
+++ b/cmd/shit/main.go
@@ -38,6 +38,7 @@ func init() {
 	rootCmd.AddCommand(plumbing.GetLsTreeCmd())
 	rootCmd.AddCommand(porcelain.GetCheckoutCmd())
 	rootCmd.AddCommand(plumbing.GetShowRefCmd())
+	rootCmd.AddCommand(porcelain.GetTagCmd())
 	// Create the directory to store the documentation
 	// err := os.MkdirAll("docs", 0755)
 	// if err != nil {

--- a/internal/git/plumbing/showref.go
+++ b/internal/git/plumbing/showref.go
@@ -20,7 +20,7 @@ var ShowRefCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		showRef(refList, true, "")
+		ShowRef(refList, true, "")
 	},
 }
 
@@ -28,7 +28,7 @@ func GetShowRefCmd() *cobra.Command {
 	return ShowRefCmd
 }
 
-func showRef(refs models.RefMap, withHash bool, prefix string) {
+func ShowRef(refs models.RefMap, withHash bool, prefix string) {
 	for k, v := range refs {
 		switch value := v.(type) {
 		case string: // If the value is a string, it's a leaf
@@ -41,7 +41,7 @@ func showRef(refs models.RefMap, withHash bool, prefix string) {
 			newPrefix := fmt.Sprintf("%s%s%s", prefix, addSlashIfNeeded(prefix), k)
 			// cast v to models.RefMap
 			v := v.(models.RefMap)
-			showRef(v, withHash, newPrefix)
+			ShowRef(v, withHash, newPrefix)
 		default:
 			fmt.Printf("Unexpected type: %v\n", reflect.TypeOf(v))
 		}

--- a/internal/git/porcelain/tag.go
+++ b/internal/git/porcelain/tag.go
@@ -3,6 +3,7 @@ package porcelain
 import (
 	"fmt"
 
+	"github.com/ShreyeshArangath/shit/internal/git/plumbing"
 	"github.com/ShreyeshArangath/shit/pkg/models"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +19,19 @@ var tagCmd = &cobra.Command{
 		tag, _ := cmd.Flags().GetString("tag")
 		object, _ := cmd.Flags().GetString("object")
 		create, _ := cmd.Flags().GetBool("create")
-		tagCreateHelper(repo, tag, object, create)
+		if tag != "" {
+			tagCreateHelper(repo, tag, object, create)
+		} else {
+			refs, err := models.ListRef(repo, "")
+			if err != nil {
+				log.Fatal(err)
+			}
+			if tags, ok := refs["tags"].(models.RefMap); ok {
+				plumbing.ShowRef(tags, true, "")
+			} else {
+				log.Fatal("Invalid type assertion for refs[\"tags\"]")
+			}
+		}
 	},
 }
 

--- a/internal/git/porcelain/tag.go
+++ b/internal/git/porcelain/tag.go
@@ -1,0 +1,54 @@
+package porcelain
+
+import (
+	"fmt"
+
+	"github.com/ShreyeshArangath/shit/pkg/models"
+	"github.com/spf13/cobra"
+)
+
+var tagCmd = &cobra.Command{
+	Use:   "tag",
+	Short: "List and create shit tag objects",
+	Run: func(cmd *cobra.Command, args []string) {
+		repo, err := models.RepoFind(".", true)
+		if err != nil {
+			log.Fatal(err)
+		}
+		tag, _ := cmd.Flags().GetString("tag")
+		object, _ := cmd.Flags().GetString("object")
+		create, _ := cmd.Flags().GetBool("create")
+		tagCreateHelper(repo, tag, object, create)
+	},
+}
+
+func init() {
+	tagCmd.Flags().StringP("tag", "t", "", "Tag name")
+	tagCmd.Flags().BoolP("create", "c", false, "Create a new tag")
+	tagCmd.Flags().StringP("object", "o", "HEAD", "Object that the tag points to")
+}
+
+func tagCreateHelper(repo *models.Repository, tag string, ref string, create bool) error {
+	sha, err := models.ObjectFind(repo, ref, "commit", false)
+	if err != nil {
+		return err
+	}
+	if create {
+		tagmetadata := models.CreateShitTagMetadataFromAttr(
+			sha,
+			"commit",
+			tag,
+			"Shreyesh Arangath <>",
+			"Tagged by shit. Cannot be customized.",
+		)
+		tagObj := models.ShitTag{TagMetadata: tagmetadata}
+		tagSha, err := models.ObjectWrite(&tagObj, repo)
+		if err != nil {
+			return err
+		}
+		models.CreateRef(repo, fmt.Sprintf("refs/tags/%s", tag), tagSha)
+	} else {
+		models.CreateRef(repo, fmt.Sprintf("refs/tags/%s", tag), sha)
+	}
+	return nil
+}

--- a/internal/git/porcelain/tag.go
+++ b/internal/git/porcelain/tag.go
@@ -22,6 +22,10 @@ var tagCmd = &cobra.Command{
 	},
 }
 
+func GetTagCmd() *cobra.Command {
+	return tagCmd
+}
+
 func init() {
 	tagCmd.Flags().StringP("tag", "t", "", "Tag name")
 	tagCmd.Flags().BoolP("create", "c", false, "Create a new tag")

--- a/internal/git/porcelain/tag.go
+++ b/internal/git/porcelain/tag.go
@@ -13,14 +13,17 @@ var tagCmd = &cobra.Command{
 	Short: "List and create shit tag objects",
 	Run: func(cmd *cobra.Command, args []string) {
 		repo, err := models.RepoFind(".", true)
+		tag, err := cmd.Flags().GetString("tag")
+		object, err := cmd.Flags().GetString("object")
+		create, err := cmd.Flags().GetBool("create")
 		if err != nil {
 			log.Fatal(err)
 		}
-		tag, _ := cmd.Flags().GetString("tag")
-		object, _ := cmd.Flags().GetString("object")
-		create, _ := cmd.Flags().GetBool("create")
 		if tag != "" {
-			tagCreateHelper(repo, tag, object, create)
+			err = tagCreateHelper(repo, tag, object, create)
+			if err != nil {
+				log.Fatal(err)
+			}
 		} else {
 			refs, err := models.ListRef(repo, "")
 			if err != nil {
@@ -63,9 +66,15 @@ func tagCreateHelper(repo *models.Repository, tag string, ref string, create boo
 		if err != nil {
 			return err
 		}
-		models.CreateRef(repo, fmt.Sprintf("refs/tags/%s", tag), tagSha)
+		err = models.CreateRef(repo, fmt.Sprintf("tags/%s", tag), tagSha)
+		if err != nil {
+			return err
+		}
 	} else {
-		models.CreateRef(repo, fmt.Sprintf("refs/tags/%s", tag), sha)
+		models.CreateRef(repo, fmt.Sprintf("tags/%s", tag), sha)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/models/tagmetadata.go
+++ b/pkg/models/tagmetadata.go
@@ -57,3 +57,18 @@ func CreateShitTagMetadata(data string) (*ShitTagMetadata, error) {
 	m.message = msgbuf.String()
 	return m, nil
 }
+
+func CreateShitTagMetadataFromAttr(
+	object string,
+	objecttype string,
+	tag string,
+	tagger string,
+	message string) *ShitTagMetadata {
+	return &ShitTagMetadata{
+		object:     object,
+		objecttype: objecttype,
+		tag:        tag,
+		tagger:     tagger,
+		message:    message,
+	}
+}


### PR DESCRIPTION
## Changelog 
- Add support for the `tag` command equivalent in git. We can now create and list tags as required. 

## Testing 
- Local testing 
```
➜  testproject git:(main) shit tag -c true  -t oh

➜  testproject git:(main) shit tag
5156e89b15019f3d6c1f14f8fc47c2ebd2451734 oh
20ffb28942ddc62e369351ac7b76474b2ea70cc7 v1.0
```