### PR TITLE
Support ObjectFind operation

### DIFF
--- a/internal/git/plumbing/lstree.go
+++ b/internal/git/plumbing/lstree.go
@@ -41,7 +41,7 @@ var lsTreeCmd = &cobra.Command{
 // For each item, it determines the object type (tree, blob, commit) and prints its details.
 // If the recursive flag is set and the item is a tree, the function calls itself recursively to list the contents of the subtree.
 func lsTreeHelper(repo *models.Repository, ref string, recursive bool, prefix string) error {
-	sha, err := models.ObjectFind(repo, ref, "tree", false)
+	sha, err := models.ObjectFind(repo, ref, "tree", true)
 	if err != nil {
 		return err
 	}

--- a/internal/git/porcelain/checkout.go
+++ b/internal/git/porcelain/checkout.go
@@ -20,7 +20,7 @@ var checkoutCmd = &cobra.Command{
 		commit, _ := cmd.Flags().GetString("commit")
 		path, _ := cmd.Flags().GetString("path")
 
-		name, err := models.ObjectFind(repo, commit, "commit", false)
+		name, err := models.ObjectFind(repo, commit, "commit", true)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/models/object.go
+++ b/pkg/models/object.go
@@ -183,7 +183,7 @@ func ObjectResolve(repo *Repository, name string) ([]string, error) {
 	re := regexp.MustCompile(`^[0-9A-Fa-f]{4,40}$`)
 
 	if name == "HEAD" {
-		ref, err := ResolveRef(repo, "HEAD")
+		ref, err := ResolveRef(repo, filepath.Join(repo.GitDir, "HEAD"))
 		return []string{ref}, err
 	}
 
@@ -205,18 +205,17 @@ func ObjectResolve(repo *Repository, name string) ([]string, error) {
 	}
 
 	// Try for references
-	asTag, _ := ResolveRef(repo, filepath.Join("refs", "tags", name))
+	asTag, _ := ResolveRef(repo, filepath.Join(repo.GitDir, "refs", "tags", name))
 	if asTag != "" {
 		candidates = append(candidates, asTag)
 	}
 
-	asBranch, _ := ResolveRef(repo, filepath.Join("refs", "heads", name))
+	asBranch, _ := ResolveRef(repo, filepath.Join(repo.GitDir, "refs", "heads", name))
 	if asBranch != "" {
 		candidates = append(candidates, asBranch)
 	}
 
 	return candidates, nil
-
 }
 
 func readBinaryFile(path string) ([]byte, error) {

--- a/pkg/models/object.go
+++ b/pkg/models/object.go
@@ -153,7 +153,40 @@ func ObjectWrite(object Object, repo *Repository) (string, error) {
 }
 
 func ObjectFind(repo *Repository, name string, objecttype string, follow bool) (string, error) {
-	return name, nil
+	sha, _ := ObjectResolve(repo, name)
+	if len(sha) == 0 {
+		return "", &ShitException{Message: fmt.Sprintf("No such reference %s", name)}
+	}
+	if len(sha) > 1 {
+		return "", &ShitException{Message: fmt.Sprintf("Ambiguous reference %s: Candidates are %s", name, strings.Join(sha, ", "))}
+	}
+	shaVal := sha[0]
+	if objecttype == "" {
+		return shaVal, nil
+	}
+
+	for {
+		obj, err := ObjectRead(repo, shaVal)
+		if err != nil {
+			return "", err
+		}
+		if obj.GetType() == objecttype {
+			return shaVal, nil
+		}
+		if !follow {
+			return "", &ShitException{Message: fmt.Sprintf("Object %s is a %s, not a %s", shaVal, obj.GetType(), objecttype)}
+		}
+
+		// Follow tags
+		objType := obj.GetType()
+		if objType == "tag" {
+			shaVal = obj.(*ShitTag).TagMetadata.object
+		} else if objType == "commit" && objecttype == "tree" {
+			shaVal = obj.(*ShitCommit).CommitMetadata.tree
+		} else {
+			return "", &ShitException{Message: fmt.Sprintf("Don't know how to dereference %s object", objType)}
+		}
+	}
 }
 
 // ObjectHash computes the hash of an object in the repository.
@@ -175,6 +208,21 @@ func ObjectHash(repo *Repository, objectype string, path string) (string, error)
 	return ObjectWrite(object, repo)
 }
 
+// ObjectResolve attempts to resolve a given object name within a repository.
+// It returns a list of candidate object names that match the provided name.
+//
+// Parameters:
+//   - repo: A pointer to the Repository where the object resides.
+//   - name: The name of the object to resolve.
+//
+// Returns:
+//   - A slice of strings containing the resolved object names.
+//   - An error if the object name is not provided or if there is an issue resolving the object.
+//
+// The function handles the following cases:
+//   - If the name is "HEAD", it resolves the HEAD reference.
+//   - If the name matches a hexadecimal pattern (4 to 40 characters), it searches for matching objects in the repository.
+//   - It also attempts to resolve the name as a tag or branch reference.
 func ObjectResolve(repo *Repository, name string) ([]string, error) {
 	if strings.TrimSpace(name) == "" {
 		return nil, &ShitException{Message: "No object name provided"}


### PR DESCRIPTION
## Changelog
Now object find operation can help resolve objects regardless of it being a reference to the HEAD, tag, or a branch. We do not need to explicitly pass in the object name (SHA1 hash) here. This should help us improve a lot more of the older commands such as ls-tree and checkout that relies on ObjectFind to find the object. 

## Testing 

```
shit checkout -c v1.0 -p /Users/sarangat/projects/emptytestdir

shit ls-tree -t HEAD  -r true
100644 blob f00b5ac0c1f1e8d1a516b155a55c868f72c7c2f0	helloworld.tx
```