### PR TITLE
Support rev-parse plumbing command

### DIFF
--- a/cmd/shit/main.go
+++ b/cmd/shit/main.go
@@ -39,6 +39,7 @@ func init() {
 	rootCmd.AddCommand(porcelain.GetCheckoutCmd())
 	rootCmd.AddCommand(plumbing.GetShowRefCmd())
 	rootCmd.AddCommand(porcelain.GetTagCmd())
+	rootCmd.AddCommand(plumbing.GetRevParseCmd())
 	// Create the directory to store the documentation
 	// err := os.MkdirAll("docs", 0755)
 	// if err != nil {

--- a/internal/git/plumbing/revparse.go
+++ b/internal/git/plumbing/revparse.go
@@ -1,0 +1,53 @@
+package plumbing
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ShreyeshArangath/shit/pkg/models"
+	"github.com/spf13/cobra"
+)
+
+var revparsecmd = &cobra.Command{
+	Use:   "rev-parse",
+	Short: "Parse revision identifiers or other object identifiers",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// Retrieve the flag value
+		objType, _ := cmd.Flags().GetString("wyag-type")
+
+		// Validate the wyag-type flag
+		validTypes := map[string]bool{
+			"blob":   true,
+			"commit": true,
+			"tag":    true,
+			"tree":   true,
+		}
+
+		if objType != "" && !validTypes[objType] {
+			fmt.Fprintf(cmd.OutOrStderr(), "Invalid type: %s. Must be one of: blob, commit, tag, tree.\n", objType)
+			os.Exit(1)
+		}
+
+		// Positional argument
+		name := args[0]
+		repo, err := models.RepoFind(".", true)
+		if err != nil {
+			log.Fatal(err)
+		}
+		obj, err := models.ObjectFind(repo, name, objType, true)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(obj)
+	},
+}
+
+func GetRevParseCmd() *cobra.Command {
+	return revparsecmd
+}
+
+func init() {
+	revparsecmd.Flags().StringP("type", "t", "", "Specify the object type")
+
+}


### PR DESCRIPTION
## Changelog 
Rev-parse will help you parse any revision identifiers or other object identifiers. This is mostly a utility command that can be used. 

## Testing 
- Local testing 

```
shit rev-parse -t commit HEAD
b5b65b9832b53ad1153a8ccdac4cb38446124984

shit rev-parse -t tag v1.0
20ffb28942ddc62e369351ac7b76474b2ea70cc7

shit rev-parse -t tag HEAD
1519c056ada87c66a34004a868c4f1cb188fade6
```